### PR TITLE
Calculate user financial summary for dashboard

### DIFF
--- a/IMPLEMENTACAO_NOVA_FORMULA.md
+++ b/IMPLEMENTACAO_NOVA_FORMULA.md
@@ -1,0 +1,173 @@
+# 🧮 Nova Fórmula de Cálculo - realMoney
+
+## 📋 Resumo da Implementação
+
+Este documento detalha a implementação da nova fórmula de cálculo solicitada: **((entradas) - (saidas)) - (salario - despesas do forms)**
+
+## 🎯 Objetivo
+
+A nova fórmula permite um controle mais preciso das finanças, separando:
+- **Transações do dia a dia** (entradas e saídas registradas)
+- **Gastos planejados** (cadastrados nos formulários: academia, hashish, etc.)
+
+## 🔧 Implementações Realizadas
+
+### 1. **Função de Cálculo Atualizada** (`app/lib/calculoAutomatico.ts`)
+
+```typescript
+export const calcularSaldoComNovaFormula = (
+  transacoes: Transacao[],
+  gastosMensais: GastoMensal[],
+  mes?: string
+): number => {
+  // Filtrar dados do mês específico
+  const totalEntradas = // soma das entradas
+  const totalSaidas = // soma das saídas  
+  const totalDespesasForms = // soma dos gastos mensais
+  const salarioTransacoes = // total de entradas (assumindo como salário)
+  
+  // Aplicar fórmula: (entradas) - (saidas) - (salario - despesas dos forms)
+  return totalEntradas - totalSaidas - (salarioTransacoes - totalDespesasForms)
+}
+```
+
+### 2. **Nova Interface para Gastos Mensais**
+
+```typescript
+export interface GastoMensal {
+  id?: number
+  user_id: string
+  mes: string
+  categoria_id: number
+  quantidade: number
+  valor_unitario?: number
+  valor_total?: number
+  created_at?: string
+  updated_at?: string
+}
+```
+
+### 3. **Gerenciador de Gastos Mensais** (`app/components/finance/GerenciadorGastos.tsx`)
+
+- Interface para criar/editar gastos mensais
+- CRUD completo (Create, Read, Update, Delete)
+- Integração com categorias existentes
+- Cálculo automático de valores totais
+
+### 4. **Dashboard Atualizado**
+
+- Nova seção "Cálculo com Nova Fórmula" mostrando breakdown detalhado
+- Botão "Gastos" na navegação inferior
+- Integração com a tabela `gastos_mensais` do novo schema
+
+## 📊 Exemplo de Funcionamento
+
+### Dados de Teste:
+- **Entradas**: R$ 6.000 (salário + freelance)
+- **Saídas**: R$ 1.200 (mercado + transporte)
+- **Despesas Forms**: R$ 495 (academia + hashish + aluguel)
+
+### Cálculo:
+```
+Fórmula: (Entradas) - (Saídas) - (Salário - Despesas Forms)
+Resultado: 6000 - 1200 - (6000 - 495) = -705
+```
+
+### Comparação:
+- **Método Antigo**: R$ 4.800 (apenas entradas - saídas)
+- **Método Novo**: R$ -705 (considerando gastos planejados)
+- **Diferença**: R$ -5.505
+
+## 🗄️ Integração com Schema
+
+A implementação utiliza as seguintes tabelas do novo schema:
+
+### `gastos_mensais`
+```sql
+CREATE TABLE public.gastos_mensais (
+  id integer NOT NULL,
+  user_id uuid NOT NULL,
+  mes character varying NOT NULL,
+  categoria_id integer NOT NULL,
+  quantidade numeric NOT NULL,
+  valor_unitario numeric,
+  valor_total numeric,
+  created_at timestamp with time zone,
+  updated_at timestamp with time zone
+);
+```
+
+### `categorias` (atualizada)
+```sql
+CREATE TABLE public.categorias (
+  id integer NOT NULL,
+  user_id uuid NOT NULL,
+  nome character varying NOT NULL,
+  tipo character varying NOT NULL,
+  unidade character varying DEFAULT 'BRL',
+  preco_unitario numeric DEFAULT 1.0,
+  icone character varying DEFAULT 'DollarSign',
+  cor character varying DEFAULT '#6b7280'
+);
+```
+
+## 🚀 Funcionalidades Implementadas
+
+### ✅ **Concluído**
+
+1. **Nova função de cálculo** seguindo a fórmula especificada
+2. **Interface para gerenciar gastos mensais**
+3. **Integração com dashboard** mostrando breakdown detalhado
+4. **Suporte a dados locais e Supabase**
+5. **Testes funcionais** validando a lógica
+
+### 📋 **API Endpoints Disponíveis**
+
+- `GET /api/monthly-expenses` - Lista gastos mensais
+- `POST /api/monthly-expenses` - Cria novo gasto mensal
+- `PUT /api/monthly-expenses/[id]` - Atualiza gasto existente
+- `DELETE /api/monthly-expenses/[id]` - Remove gasto
+
+## 🧪 Teste Executado
+
+O arquivo `test_nova_formula.js` valida:
+- ✅ Filtragem correta por mês
+- ✅ Cálculo das entradas e saídas
+- ✅ Soma dos gastos mensais
+- ✅ Aplicação da fórmula
+- ✅ Comparação com método anterior
+
+## 🎨 Interface do Usuário
+
+### Dashboard
+- Nova seção destacada mostrando o cálculo detalhado
+- Cards coloridos para cada componente da fórmula
+- Explicação da fórmula aplicada
+
+### Gerenciador de Gastos
+- Modal moderno e responsivo
+- Formulário intuitivo com validação
+- Lista de gastos com opções de edição/exclusão
+- Integração automática com categorias
+
+## 🔄 Como Usar
+
+1. **Acesse o Dashboard**
+2. **Clique em "Gastos"** na navegação inferior
+3. **Adicione gastos mensais** (academia, hashish, etc.)
+4. **Visualize o cálculo** na seção "Nova Fórmula"
+5. **Compare** com o método anterior
+
+## 💡 Benefícios da Nova Abordagem
+
+- **Precisão**: Considera todos os tipos de gastos
+- **Planejamento**: Separa gastos fixos de variáveis
+- **Visibilidade**: Mostra breakdown completo
+- **Flexibilidade**: Permite ajustes categorizados
+- **Histórico**: Mantém registro detalhado por mês
+
+---
+
+**Status**: ✅ **IMPLEMENTADO E TESTADO**  
+**Data**: Janeiro 2025  
+**Versão**: 1.0.0

--- a/app/components/finance/Dashboard.tsx
+++ b/app/components/finance/Dashboard.tsx
@@ -44,6 +44,7 @@ import ModalNovoMes from '../ui/ModalNovoMes'
 import ListaTransacoes from './ListaTransacoes'
 import GerenciadorCategorias from './GerenciadorCategorias'
 import GerenciadorContatos from './GerenciadorContatos'
+import GerenciadorGastos from './GerenciadorGastos'
 import ImportarExtrato from '../ui/ImportarExtrato'
 import { gerarInsightAvancado } from '../../lib/insightEngine'
 import useThemeSwitcher from '../../hooks/useThemeSwitcher'
@@ -56,6 +57,7 @@ import type {
   Transacao,
   Categoria,
   GastosMensais,
+  GastoMensal,
   ResumoMensal
 } from '../../types/types'
 import { 
@@ -64,12 +66,15 @@ import {
   calcularTotalEntradas,
   calcularTotalSaidas,
   calcularSobraMensal,
-  deveAtualizarResumoAutomatico
+  deveAtualizarResumoAutomatico,
+  calcularSaldoComNovaFormula,
+  obterResumoDetalhado
 } from '../../lib/calculoAutomatico'
 
 export default function Dashboard() {
   const { theme, toggleTheme } = useThemeSwitcher()
   const [gastos, setGastos] = useState<any[]>([])
+  const [gastosMensais, setGastosMensais] = useState<GastoMensal[]>([])
   const [config, setConfig] = useState<ConfiguracoesType | null>(null)
   const [transacoes, setTransacoes] = useState<Transacao[]>([])
   const [loading, setLoading] = useState(true)
@@ -82,6 +87,7 @@ export default function Dashboard() {
   const [showModalNovoMes, setShowModalNovoMes] = useState(false)
   const [showGerenciadorCategorias, setShowGerenciadorCategorias] = useState(false)
   const [showGerenciadorContatos, setShowGerenciadorContatos] = useState(false)
+  const [showGerenciadorGastos, setShowGerenciadorGastos] = useState(false)
   const [tipoTransacaoRapida, setTipoTransacaoRapida] = useState<'entrada' | 'saida'>('saida')
   const [showImportExtrato, setShowImportExtrato] = useState(false)
   const toast = useToast()
@@ -275,6 +281,15 @@ export default function Dashboard() {
         }))
 
         setTransacoes(transacoesMapeadas)
+
+        // Carregar gastos mensais do usuário
+        const { data: gastosMensaisData } = await supabase
+          .from('gastos_mensais')
+          .select('*')
+          .eq('user_id', user.id)
+          .order('created_at', { ascending: false })
+
+        setGastosMensais(gastosMensaisData || [])
         
         // Comentado para evitar zerar dados - a atualização agora é feita apenas ao adicionar transações
         // await atualizarResumosAutomaticamente(resumosMapeados, transacoesMapeadas, [], user.id)
@@ -294,6 +309,7 @@ export default function Dashboard() {
         try {
           const localGastos = JSON.parse(localStorage.getItem('gastos') || '[]')
           const localTransacoes = JSON.parse(localStorage.getItem('transacoes') || '[]')
+          const localGastosMensais = JSON.parse(localStorage.getItem('gastos_mensais') || '[]')
           
           if (localGastos.length > 0) {
             const gastosComTransacoes = associarTransacoesAosMeses(localGastos, localTransacoes)
@@ -325,6 +341,7 @@ export default function Dashboard() {
             updatedAt: t.updatedAt,
           }))
           setTransacoes(transacoesMapeadas)
+          setGastosMensais(localGastosMensais)
         } catch (localError) {
           toast.error('Erro ao carregar dados locais, usando mockados')
           setGastos(mockGastos)
@@ -377,9 +394,9 @@ export default function Dashboard() {
   }
 
   const calcularSobra = (item: any) => {
-    const custoHashish = item.hashish * 95; // Calculate total cost of hashish
-    const totalGastos = item.cartaoCredito + item.contasFixas + custoHashish + item.mercado + item.gasolina + (item.outros || 0);
-    return item.salarioLiquido + item.flash - totalGastos;
+    // Usar a nova fórmula: (entradas) - (saidas) - (salario - despesas dos forms)
+    const resumoDetalhado = obterResumoDetalhado(transacoes, gastosMensais, item.mes)
+    return resumoDetalhado.saldoFinal
   }
 
   const calcularDadosGraficoGastos = (): GraficoGastos[] => {
@@ -914,6 +931,13 @@ export default function Dashboard() {
                     <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Detalhamento do Mês</h3>
                     <div className="flex space-x-2">
                       <button
+                        onClick={() => setShowGerenciadorGastos(true)}
+                        className="inline-flex items-center px-3 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition-colors"
+                      >
+                        <DollarSign className="h-4 w-4 mr-2" />
+                        Gastos
+                      </button>
+                      <button
                         onClick={() => handleEditar(selectedMonth)}
                         className="inline-flex items-center px-3 py-2 bg-gray-900 text-white text-sm font-medium rounded-lg hover:bg-gray-800 transition-colors"
                       >
@@ -984,6 +1008,92 @@ export default function Dashboard() {
                       <p className="text-lg font-semibold text-green-600">
                         R$ {calcularSobra(selectedMonth).toLocaleString('pt-BR')}
                       </p>
+                    </div>
+                  </div>
+                </motion.div>
+              )}
+
+              {/* Bloco 5.5 – Nova Fórmula de Cálculo */}
+              {selectedMonth && (
+                <motion.div
+                  variants={cardVariants}
+                  initial="hidden"
+                  animate="visible"
+                  className="bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-blue-900/20 dark:to-indigo-900/20 rounded-xl shadow-sm border border-blue-200 dark:border-blue-800 p-6"
+                >
+                  <div className="flex items-center space-x-3 mb-6">
+                    <div className="p-2 bg-blue-100 dark:bg-blue-800 rounded-lg">
+                      <Zap className="h-5 w-5 text-blue-600 dark:text-blue-300" />
+                    </div>
+                    <div>
+                      <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Cálculo com Nova Fórmula</h3>
+                      <p className="text-gray-500 dark:text-gray-400">Baseado na nova metodologia: (Entradas) - (Saídas) - (Salário - Despesas dos Forms)</p>
+                    </div>
+                  </div>
+
+                  {(() => {
+                    const resumoDetalhado = obterResumoDetalhado(transacoes, gastosMensais, selectedMonth.mes)
+                    return (
+                      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+                        <div className="p-4 bg-white dark:bg-gray-800 rounded-lg border border-blue-100 dark:border-blue-700">
+                          <div className="flex items-center space-x-2 mb-2">
+                            <TrendingUp className="h-4 w-4 text-green-500" />
+                            <span className="text-sm text-gray-500 dark:text-gray-400">Total Entradas</span>
+                          </div>
+                          <p className="text-lg font-semibold text-green-600">
+                            R$ {resumoDetalhado.totalEntradas.toLocaleString('pt-BR')}
+                          </p>
+                        </div>
+
+                        <div className="p-4 bg-white dark:bg-gray-800 rounded-lg border border-blue-100 dark:border-blue-700">
+                          <div className="flex items-center space-x-2 mb-2">
+                            <TrendingDown className="h-4 w-4 text-red-500" />
+                            <span className="text-sm text-gray-500 dark:text-gray-400">Total Saídas</span>
+                          </div>
+                          <p className="text-lg font-semibold text-red-600">
+                            R$ {resumoDetalhado.totalSaidas.toLocaleString('pt-BR')}
+                          </p>
+                        </div>
+
+                        <div className="p-4 bg-white dark:bg-gray-800 rounded-lg border border-blue-100 dark:border-blue-700">
+                          <div className="flex items-center space-x-2 mb-2">
+                            <DollarSign className="h-4 w-4 text-purple-500" />
+                            <span className="text-sm text-gray-500 dark:text-gray-400">Despesas Forms</span>
+                          </div>
+                          <p className="text-lg font-semibold text-purple-600">
+                            R$ {resumoDetalhado.totalDespesasForms.toLocaleString('pt-BR')}
+                          </p>
+                        </div>
+
+                        <div className="p-4 bg-white dark:bg-gray-800 rounded-lg border border-blue-100 dark:border-blue-700">
+                          <div className="flex items-center space-x-2 mb-2">
+                            <Target className="h-4 w-4 text-blue-500" />
+                            <span className="text-sm text-gray-500 dark:text-gray-400">Saldo Final</span>
+                          </div>
+                          <p className={`text-lg font-semibold ${
+                            resumoDetalhado.saldoFinal >= 0 ? 'text-green-600' : 'text-red-600'
+                          }`}>
+                            R$ {resumoDetalhado.saldoFinal.toLocaleString('pt-BR')}
+                          </p>
+                        </div>
+                      </div>
+                    )
+                  })()}
+
+                  <div className="mt-6 p-4 bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-700 rounded-lg">
+                    <div className="flex items-start space-x-3">
+                      <Info className="h-5 w-5 text-blue-500 dark:text-blue-400 mt-0.5" />
+                      <div>
+                        <h4 className="font-medium text-blue-900 dark:text-blue-100 mb-1">Fórmula Aplicada</h4>
+                        {(() => {
+                          const resumoDetalhado = obterResumoDetalhado(transacoes, gastosMensais, selectedMonth.mes)
+                          return (
+                            <p className="text-sm text-blue-700 dark:text-blue-300">
+                              {resumoDetalhado.detalhesCalculo.resultado}
+                            </p>
+                          )
+                        })()}
+                      </div>
                     </div>
                   </div>
                 </motion.div>
@@ -1190,6 +1300,14 @@ export default function Dashboard() {
             </button>
 
             <button
+              onClick={() => setShowGerenciadorGastos(true)}
+              className="flex flex-col items-center py-2 px-3 rounded-lg transition-colors text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
+            >
+              <DollarSign className="h-5 w-5 mb-1" />
+              <span className="text-xs">Gastos</span>
+            </button>
+
+            <button
               onClick={() => setShowModalNovoMes(true)}
               className="flex flex-col items-center py-2 px-3 rounded-lg transition-colors text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
             >
@@ -1240,6 +1358,16 @@ export default function Dashboard() {
         onSuccess={() => {
           carregarDados() // Recarregar dados após alterações nos contatos
         }}
+      />
+
+      {/* Modal de Gerenciador de Gastos */}
+      <GerenciadorGastos
+        isOpen={showGerenciadorGastos}
+        onClose={() => setShowGerenciadorGastos(false)}
+        onSuccess={() => {
+          carregarDados() // Recarregar dados após alterações nos gastos
+        }}
+        mesSelecionado={selectedMonth?.mes}
       />
 
       <ImportarExtrato

--- a/app/components/finance/GerenciadorGastos.tsx
+++ b/app/components/finance/GerenciadorGastos.tsx
@@ -1,0 +1,472 @@
+'use client'
+import { useState, useEffect } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import { 
+  X, 
+  Plus, 
+  Edit3, 
+  Trash2, 
+  Save,
+  DollarSign,
+  Calendar,
+  Tag,
+  Hash
+} from 'lucide-react'
+import { useToast } from '../../lib/useToast'
+import { supabase } from '../../lib/supabaseClient'
+import type { GastoMensal, Categoria } from '../../types/types'
+
+interface Props {
+  isOpen: boolean
+  onClose: () => void
+  onSuccess: () => void
+  mesSelecionado?: string
+}
+
+export default function GerenciadorGastos({ isOpen, onClose, onSuccess, mesSelecionado }: Props) {
+  const [gastos, setGastos] = useState<GastoMensal[]>([])
+  const [categorias, setCategorias] = useState<Categoria[]>([])
+  const [loading, setLoading] = useState(false)
+  const [showForm, setShowForm] = useState(false)
+  const [editingGasto, setEditingGasto] = useState<GastoMensal | null>(null)
+  const [formData, setFormData] = useState<Partial<GastoMensal>>({
+    mes: mesSelecionado || '',
+    categoria_id: 0,
+    quantidade: 0,
+    valor_unitario: 0,
+    valor_total: 0
+  })
+  const toast = useToast()
+
+  useEffect(() => {
+    if (isOpen) {
+      carregarDados()
+    }
+  }, [isOpen])
+
+  useEffect(() => {
+    if (mesSelecionado) {
+      setFormData(prev => ({ ...prev, mes: mesSelecionado }))
+    }
+  }, [mesSelecionado])
+
+  const carregarDados = async () => {
+    setLoading(true)
+    try {
+      const { data: { user } } = await supabase.auth.getUser()
+      
+      if (user) {
+        // Carregar gastos mensais
+        const { data: gastosData } = await supabase
+          .from('gastos_mensais')
+          .select('*')
+          .eq('user_id', user.id)
+          .order('created_at', { ascending: false })
+
+        // Carregar categorias
+        const { data: categoriasData } = await supabase
+          .from('categorias')
+          .select('*')
+          .eq('user_id', user.id)
+          .order('nome')
+
+        setGastos(gastosData || [])
+        setCategorias(categoriasData || [])
+      } else {
+        // Dados locais
+        const gastosLocal = JSON.parse(localStorage.getItem('gastos_mensais') || '[]')
+        const categoriasLocal = JSON.parse(localStorage.getItem('categorias') || '[]')
+        setGastos(gastosLocal)
+        setCategorias(categoriasLocal)
+      }
+    } catch (error) {
+      toast.error('Erro ao carregar dados')
+      setGastos([])
+      setCategorias([])
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!formData.categoria_id || formData.quantidade <= 0) {
+      toast.error('Preencha todos os campos obrigatórios')
+      return
+    }
+
+    setLoading(true)
+    try {
+      const { data: { user } } = await supabase.auth.getUser()
+      
+      // Calcular valor total se não foi informado
+      const valorTotal = formData.valor_total || (formData.quantidade * (formData.valor_unitario || 0))
+      
+      const gastoData = {
+        ...formData,
+        valor_total: valorTotal,
+        user_id: user?.id || 'local'
+      }
+
+      if (user) {
+        if (editingGasto) {
+          // Atualizar
+          await supabase
+            .from('gastos_mensais')
+            .update(gastoData)
+            .eq('id', editingGasto.id)
+        } else {
+          // Criar
+          await supabase
+            .from('gastos_mensais')
+            .insert([gastoData])
+        }
+      } else {
+        // Dados locais
+        const gastosLocal = JSON.parse(localStorage.getItem('gastos_mensais') || '[]')
+        
+        if (editingGasto) {
+          const index = gastosLocal.findIndex((g: GastoMensal) => g.id === editingGasto.id)
+          if (index !== -1) {
+            gastosLocal[index] = { ...gastoData, id: editingGasto.id, updated_at: new Date().toISOString() }
+          }
+        } else {
+          const novoGasto = {
+            ...gastoData,
+            id: Date.now(),
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString()
+          }
+          gastosLocal.push(novoGasto)
+        }
+        
+        localStorage.setItem('gastos_mensais', JSON.stringify(gastosLocal))
+      }
+
+      toast.success(editingGasto ? 'Gasto atualizado!' : 'Gasto criado!')
+      setShowForm(false)
+      setEditingGasto(null)
+      setFormData({
+        mes: mesSelecionado || '',
+        categoria_id: 0,
+        quantidade: 0,
+        valor_unitario: 0,
+        valor_total: 0
+      })
+      carregarDados()
+      onSuccess()
+    } catch (error) {
+      toast.error('Erro ao salvar gasto')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleEdit = (gasto: GastoMensal) => {
+    setEditingGasto(gasto)
+    setFormData(gasto)
+    setShowForm(true)
+  }
+
+  const handleDelete = async (gasto: GastoMensal) => {
+    if (!confirm('Tem certeza que deseja excluir este gasto?')) return
+
+    setLoading(true)
+    try {
+      const { data: { user } } = await supabase.auth.getUser()
+      
+      if (user) {
+        await supabase
+          .from('gastos_mensais')
+          .delete()
+          .eq('id', gasto.id)
+      } else {
+        const gastosLocal = JSON.parse(localStorage.getItem('gastos_mensais') || '[]')
+        const gastosFiltrados = gastosLocal.filter((g: GastoMensal) => g.id !== gasto.id)
+        localStorage.setItem('gastos_mensais', JSON.stringify(gastosFiltrados))
+      }
+
+      toast.success('Gasto excluído!')
+      carregarDados()
+      onSuccess()
+    } catch (error) {
+      toast.error('Erro ao excluir gasto')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const getCategoriaInfo = (categoriaId: number) => {
+    const categoria = categorias.find(c => c.id === categoriaId)
+    return categoria || { nome: 'Categoria não encontrada', unidade: 'unidade', preco_unitario: 0 }
+  }
+
+  if (!isOpen) return null
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        className="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4"
+        onClick={onClose}
+      >
+        <motion.div
+          initial={{ scale: 0.95, opacity: 0 }}
+          animate={{ scale: 1, opacity: 1 }}
+          exit={{ scale: 0.95, opacity: 0 }}
+          className="bg-white rounded-xl shadow-xl max-w-4xl w-full max-h-[90vh] overflow-hidden"
+          onClick={e => e.stopPropagation()}
+        >
+          {/* Header */}
+          <div className="flex items-center justify-between p-6 border-b border-gray-200">
+            <div>
+              <h2 className="text-xl font-semibold text-gray-900">Gastos Mensais</h2>
+              <p className="text-sm text-gray-500">Gerencie suas categorias de gastos mensais</p>
+            </div>
+            <button
+              onClick={onClose}
+              className="p-2 hover:bg-gray-100 rounded-lg transition-colors"
+            >
+              <X className="h-5 w-5 text-gray-400" />
+            </button>
+          </div>
+
+          {/* Content */}
+          <div className="p-6 overflow-y-auto max-h-[calc(90vh-120px)]">
+            {!showForm ? (
+              <div className="space-y-6">
+                {/* Actions */}
+                <div className="flex justify-between items-center">
+                  <h3 className="text-lg font-medium text-gray-900">Gastos Cadastrados</h3>
+                  <button
+                    onClick={() => setShowForm(true)}
+                    className="inline-flex items-center px-4 py-2 bg-gray-900 text-white text-sm font-medium rounded-lg hover:bg-gray-800 transition-colors"
+                  >
+                    <Plus className="h-4 w-4 mr-2" />
+                    Novo Gasto
+                  </button>
+                </div>
+
+                {/* Lista de Gastos */}
+                {loading ? (
+                  <div className="text-center py-8">
+                    <p className="text-gray-500">Carregando gastos...</p>
+                  </div>
+                ) : gastos.length === 0 ? (
+                  <div className="text-center py-8">
+                    <div className="w-16 h-16 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4">
+                      <DollarSign className="h-8 w-8 text-gray-400" />
+                    </div>
+                    <p className="text-gray-500 mb-4">Nenhum gasto cadastrado</p>
+                    <button
+                      onClick={() => setShowForm(true)}
+                      className="text-gray-900 underline"
+                    >
+                      Criar primeiro gasto
+                    </button>
+                  </div>
+                ) : (
+                  <div className="grid gap-4">
+                    {gastos.map((gasto) => {
+                      const categoria = getCategoriaInfo(gasto.categoria_id)
+                      return (
+                        <motion.div
+                          key={gasto.id}
+                          layout
+                          className="p-4 border border-gray-200 rounded-lg hover:border-gray-300 transition-colors"
+                        >
+                          <div className="flex items-center justify-between">
+                            <div className="flex-1">
+                              <div className="flex items-center space-x-3 mb-2">
+                                <div className="w-8 h-8 bg-gray-100 rounded-lg flex items-center justify-center">
+                                  <Tag className="h-4 w-4 text-gray-600" />
+                                </div>
+                                <div>
+                                  <h4 className="font-medium text-gray-900">{categoria.nome}</h4>
+                                  <p className="text-sm text-gray-500">{gasto.mes}</p>
+                                </div>
+                              </div>
+                              <div className="grid grid-cols-3 gap-4 text-sm">
+                                <div>
+                                  <span className="text-gray-500">Quantidade:</span>
+                                  <p className="font-medium">{gasto.quantidade} {categoria.unidade || 'unidades'}</p>
+                                </div>
+                                <div>
+                                  <span className="text-gray-500">Valor Unitário:</span>
+                                  <p className="font-medium">R$ {(gasto.valor_unitario || 0).toLocaleString('pt-BR')}</p>
+                                </div>
+                                <div>
+                                  <span className="text-gray-500">Total:</span>
+                                  <p className="font-medium text-green-600">R$ {(gasto.valor_total || 0).toLocaleString('pt-BR')}</p>
+                                </div>
+                              </div>
+                            </div>
+                            <div className="flex items-center space-x-2 ml-4">
+                              <button
+                                onClick={() => handleEdit(gasto)}
+                                className="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded transition-colors"
+                              >
+                                <Edit3 className="h-4 w-4" />
+                              </button>
+                              <button
+                                onClick={() => handleDelete(gasto)}
+                                className="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded transition-colors"
+                              >
+                                <Trash2 className="h-4 w-4" />
+                              </button>
+                            </div>
+                          </div>
+                        </motion.div>
+                      )
+                    })}
+                  </div>
+                )}
+              </div>
+            ) : (
+              /* Form */
+              <div className="space-y-6">
+                <div className="flex items-center justify-between">
+                  <h3 className="text-lg font-medium text-gray-900">
+                    {editingGasto ? 'Editar Gasto' : 'Novo Gasto'}
+                  </h3>
+                  <button
+                    onClick={() => {
+                      setShowForm(false)
+                      setEditingGasto(null)
+                      setFormData({
+                        mes: mesSelecionado || '',
+                        categoria_id: 0,
+                        quantidade: 0,
+                        valor_unitario: 0,
+                        valor_total: 0
+                      })
+                    }}
+                    className="text-gray-400 hover:text-gray-600 transition-colors"
+                  >
+                    <X className="h-5 w-5" />
+                  </button>
+                </div>
+
+                <form onSubmit={handleSubmit} className="space-y-4">
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-2">
+                        <Calendar className="h-4 w-4 inline mr-1" />
+                        Mês
+                      </label>
+                      <input
+                        type="text"
+                        value={formData.mes}
+                        onChange={(e) => setFormData({...formData, mes: e.target.value})}
+                        className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-gray-500 focus:border-transparent"
+                        placeholder="Ex: Janeiro 2024"
+                        required
+                      />
+                    </div>
+
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-2">
+                        <Tag className="h-4 w-4 inline mr-1" />
+                        Categoria
+                      </label>
+                      <select
+                        value={formData.categoria_id}
+                        onChange={(e) => setFormData({...formData, categoria_id: Number(e.target.value)})}
+                        className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-gray-500 focus:border-transparent"
+                        required
+                      >
+                        <option value={0}>Selecione uma categoria</option>
+                        {categorias.map(categoria => (
+                          <option key={categoria.id} value={categoria.id}>
+                            {categoria.nome} ({categoria.unidade || 'unidade'})
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-2">
+                        <Hash className="h-4 w-4 inline mr-1" />
+                        Quantidade
+                      </label>
+                      <input
+                        type="number"
+                        step="0.01"
+                        min="0"
+                        value={formData.quantidade}
+                        onChange={(e) => setFormData({...formData, quantidade: Number(e.target.value)})}
+                        className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-gray-500 focus:border-transparent"
+                        required
+                      />
+                    </div>
+
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-2">
+                        <DollarSign className="h-4 w-4 inline mr-1" />
+                        Valor Unitário
+                      </label>
+                      <input
+                        type="number"
+                        step="0.01"
+                        min="0"
+                        value={formData.valor_unitario}
+                        onChange={(e) => setFormData({...formData, valor_unitario: Number(e.target.value)})}
+                        className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-gray-500 focus:border-transparent"
+                      />
+                    </div>
+
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-2">
+                        <DollarSign className="h-4 w-4 inline mr-1" />
+                        Valor Total (opcional)
+                      </label>
+                      <input
+                        type="number"
+                        step="0.01"
+                        min="0"
+                        value={formData.valor_total}
+                        onChange={(e) => setFormData({...formData, valor_total: Number(e.target.value)})}
+                        className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-gray-500 focus:border-transparent"
+                        placeholder="Calculado automaticamente se vazio"
+                      />
+                    </div>
+                  </div>
+
+                  <div className="flex justify-end space-x-3 pt-4 border-t border-gray-200">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setShowForm(false)
+                        setEditingGasto(null)
+                        setFormData({
+                          mes: mesSelecionado || '',
+                          categoria_id: 0,
+                          quantidade: 0,
+                          valor_unitario: 0,
+                          valor_total: 0
+                        })
+                      }}
+                      className="px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors"
+                    >
+                      Cancelar
+                    </button>
+                    <button
+                      type="submit"
+                      disabled={loading}
+                      className="inline-flex items-center px-4 py-2 bg-gray-900 text-white rounded-lg hover:bg-gray-800 transition-colors disabled:opacity-50"
+                    >
+                      <Save className="h-4 w-4 mr-2" />
+                      {loading ? 'Salvando...' : 'Salvar'}
+                    </button>
+                  </div>
+                </form>
+              </div>
+            )}
+          </div>
+        </motion.div>
+      </motion.div>
+    </AnimatePresence>
+  )
+}

--- a/app/types/types.ts
+++ b/app/types/types.ts
@@ -14,7 +14,10 @@ export interface Categoria {
   user_id: string
   nome: string
   tipo: 'entrada' | 'saida'
+  unidade?: string
+  preco_unitario?: number
   icone?: string
+  cor?: string
   created_at?: string
 }
 
@@ -36,6 +39,18 @@ export interface Transacao {
   contato_id?: number
   descricao?: string
   created_at?: string
+}
+
+export interface GastoMensal {
+  id?: number
+  user_id: string
+  mes: string
+  categoria_id: number
+  quantidade: number
+  valor_unitario?: number
+  valor_total?: number
+  created_at?: string
+  updated_at?: string
 }
 
 export interface ResumoMensal {

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -14,15 +14,16 @@
     "framer-motion": "^12.23.9",
     "lucide-react": "^0.526.0",
     "next": "14.1.0",
+    "papaparse": "^5.4.1",
     "postcss": "8.4.24",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-hot-toast": "^2.4.1",
-    "papaparse": "^5.4.1",
     "recharts": "2.8.0",
     "tailwindcss": "3.4.1"
   },
   "devDependencies": {
+    "@types/node": "24.1.0",
     "@types/react": "19.1.8",
     "typescript": "5.4.3"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       next:
         specifier: 14.1.0
         version: 14.1.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      papaparse:
+        specifier: ^5.4.1
+        version: 5.5.3
       postcss:
         specifier: 8.4.24
         version: 8.4.24
@@ -45,6 +48,9 @@ importers:
         specifier: 3.4.1
         version: 3.4.1
     devDependencies:
+      '@types/node':
+        specifier: 24.1.0
+        version: 24.1.0
       '@types/react':
         specifier: 19.1.8
         version: 19.1.8
@@ -599,6 +605,9 @@ packages:
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  papaparse@5.5.3:
+    resolution: {integrity: sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -1391,6 +1400,8 @@ snapshots:
   object-hash@3.0.0: {}
 
   package-json-from-dist@1.0.1: {}
+
+  papaparse@5.5.3: {}
 
   path-key@3.1.1: {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,8 @@
       {
         "name": "next"
       }
-    ]
+    ],
+    "target": "ES2017"
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
Implement a new dashboard financial calculation `(entradas - saidas) - (salario - despesas do forms)` and add a monthly expenses manager to provide a more precise financial overview.

The previous dashboard calculation only considered direct transactions. This PR introduces a new formula and a dedicated interface for managing "despesas do forms" (monthly planned expenses like gym, rent, etc.), allowing the dashboard to display a more comprehensive and accurate financial picture by incorporating these recurring costs into the main balance.

---

[Open in Web](https://cursor.com/agents?id=bc-011a65c5-a31a-480c-a60e-e05ef01b9607) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-011a65c5-a31a-480c-a60e-e05ef01b9607) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)